### PR TITLE
Removed unnecessary module export

### DIFF
--- a/code/backend/queries/EventOps.cts
+++ b/code/backend/queries/EventOps.cts
@@ -1,18 +1,17 @@
 const g_coRouter = require("express").Router()
-const g_csRoot = require("../utilities/root.cts")
 const g_coEvents = require("../server/main.cts").get("DB").collection("events")
 const g_codes = require("../server/data.cts").get("Status codes")
 
-g_coRouter.post(g_csRoot, function(a_oRequest, a_oResponse) {
+g_coRouter.post("/", function(a_oRequest, a_oResponse) {
 	
 })
-g_coRouter.get(g_csRoot, function(a_oRequest, a_oResponse) {
+g_coRouter.get("/", function(a_oRequest, a_oResponse) {
 
 })
-g_coRouter.put(g_csRoot, function(a_oRequest, a_oResponse) {
+g_coRouter.put("/", function(a_oRequest, a_oResponse) {
 	
 })
-g_coRouter.delete(g_csRoot, function(a_oRequest, a_oResponse) {
+g_coRouter.delete("/", function(a_oRequest, a_oResponse) {
 	
 })
 

--- a/code/backend/queries/EventOps.cts
+++ b/code/backend/queries/EventOps.cts
@@ -7,7 +7,7 @@ g_coRouter.post(g_csRoot, function(a_oRequest, a_oResponse) {
 	
 })
 g_coRouter.get(g_csRoot, function(a_oRequest, a_oResponse) {
-	
+
 })
 g_coRouter.put(g_csRoot, function(a_oRequest, a_oResponse) {
 	

--- a/code/backend/queries/InvitationOps.cts
+++ b/code/backend/queries/InvitationOps.cts
@@ -1,18 +1,17 @@
 const g_coRouter = require("express").Router()
-const g_csRoot = require("../utilities/root.cts")
 const g_coInvitations = require("../server/main.cts").get("DB").collection("invitations")
 const g_codes = require("../server/data.cts").get("Status codes")
 
-g_coRouter.post(g_csRoot, function(a_oRequest, a_oResponse) {
+g_coRouter.post("/", function(a_oRequest, a_oResponse) {
 	
 })
-g_coRouter.get(g_csRoot, function(a_oRequest, a_oResponse) {
+g_coRouter.get("/", function(a_oRequest, a_oResponse) {
 	
 })
-g_coRouter.put(g_csRoot, function(a_oRequest, a_oResponse) {
+g_coRouter.put("/", function(a_oRequest, a_oResponse) {
 	
 })
-g_coRouter.delete(g_csRoot, function(a_oRequest, a_oResponse) {
+g_coRouter.delete("/", function(a_oRequest, a_oResponse) {
 	
 })
 

--- a/code/backend/queries/MesOps.cts
+++ b/code/backend/queries/MesOps.cts
@@ -1,18 +1,17 @@
 const g_coRouter = require("express").Router()
-const g_csRoot = require("../utilities/root.cts")
 const g_coMessages = require("../server/main.cts").get("DB").collection("messages")
 const g_codes = require("../server/data.cts").get("Status codes")
 
-g_coRouter.post(g_csRoot, function(a_oRequest, a_oResponse) {
+g_coRouter.post("/", function(a_oRequest, a_oResponse) {
 	
 })
-g_coRouter.get(g_csRoot, function(a_oRequest, a_oResponse) {
+g_coRouter.get("/", function(a_oRequest, a_oResponse) {
 	
 })
-g_coRouter.put(g_csRoot, function(a_oRequest, a_oResponse) {
+g_coRouter.put("/", function(a_oRequest, a_oResponse) {
 	
 })
-g_coRouter.delete(g_csRoot, function(a_oRequest, a_oResponse) {
+g_coRouter.delete("/", function(a_oRequest, a_oResponse) {
 	
 })
 

--- a/code/backend/queries/NotifOps.cts
+++ b/code/backend/queries/NotifOps.cts
@@ -1,18 +1,17 @@
 const g_coRouter = require("express").Router()
-const g_csRoot = require("../utilities/root.cts")
 const g_coNotifications = require("../server/main.cts").get("DB").collection("notifications")
 const g_codes = require("../server/data.cts").get("Status codes")
 
-g_coRouter.post(g_csRoot, function(a_oRequest, a_oResponse) {
+g_coRouter.post("/", function(a_oRequest, a_oResponse) {
 	
 })
-g_coRouter.get(g_csRoot, function(a_oRequest, a_oResponse) {
+g_coRouter.get("/", function(a_oRequest, a_oResponse) {
 	
 })
-g_coRouter.put(g_csRoot, function(a_oRequest, a_oResponse) {
+g_coRouter.put("/", function(a_oRequest, a_oResponse) {
 	
 })
-g_coRouter.delete(g_csRoot, function(a_oRequest, a_oResponse) {
+g_coRouter.delete("/", function(a_oRequest, a_oResponse) {
 	
 })
 

--- a/code/backend/queries/RequestOps.cts
+++ b/code/backend/queries/RequestOps.cts
@@ -1,18 +1,17 @@
 const g_coRouter = require("express").Router()
-const g_csRoot = require("../utilities/root.cts")
 const g_coRequests = require("../server/main.cts").get("DB").collection("requests")
 const g_codes = require("../server/data.cts").get("Status codes")
 
-g_coRouter.post(g_csRoot, function(a_oRequest, a_oResponse) {
+g_coRouter.post("/", function(a_oRequest, a_oResponse) {
 	
 })
-g_coRouter.get(g_csRoot, function(a_oRequest, a_oResponse) {
+g_coRouter.get("/", function(a_oRequest, a_oResponse) {
 	
 })
-g_coRouter.put(g_csRoot, function(a_oRequest, a_oResponse) {
+g_coRouter.put("/", function(a_oRequest, a_oResponse) {
 	
 })
-g_coRouter.delete(g_csRoot, function(a_oRequest, a_oResponse) {
+g_coRouter.delete("/", function(a_oRequest, a_oResponse) {
 	
 })
 

--- a/code/backend/queries/UserOps.cts
+++ b/code/backend/queries/UserOps.cts
@@ -1,19 +1,18 @@
 const g_coRouter = require("express").Router()
-const g_csRoot = require("../utilities/root.cts")
 const g_cAuth = require("../server/auth.cts")
 const g_coUsers = require("../server/main.cts").get("DB").collection("users")
 const g_codes = require("../server/data.cts").get("Status codes")
 
-g_coRouter.post(g_csRoot, function(a_oRequest, a_oResponse) {
+g_coRouter.post("/", function(a_oRequest, a_oResponse) {
 	
 })
-g_coRouter.get(g_csRoot, function(a_oRequest, a_oResponse) {
+g_coRouter.get("/", function(a_oRequest, a_oResponse) {
 	
 })
-g_coRouter.put(g_csRoot, g_cAuth, function(a_oRequest, a_oResponse) {
+g_coRouter.put("/", g_cAuth, function(a_oRequest, a_oResponse) {
 	
 })
-g_coRouter.delete(g_csRoot, g_cAuth, function(a_oRequest, a_oResponse) {
+g_coRouter.delete("/", g_cAuth, function(a_oRequest, a_oResponse) {
 	
 })
 

--- a/code/backend/queries/logging.cts
+++ b/code/backend/queries/logging.cts
@@ -1,9 +1,8 @@
 const g_coRouter = require("express").Router()
-const g_csRoot = require("../utilities/root.cts")
 const g_coUsers = require("../server/main.cts").get("DB").collection("users")
 const g_codes = require("../server/data.cts").get("Status codes")
 
-g_coRouter.use(g_csRoot + "in", function(a_oRequest, a_oResponse) {
+g_coRouter.use("/in", function(a_oRequest, a_oResponse) {
 	const { m_sUsername, m_sPassword } = a_oRequest.headers
 	if (!m_sUsername) return a_oResponse.sendStatus(g_codes.get("Invalid"))
 	const l_coUser = g_coUsers.findOne({ username: m_sUsername }).project({ password: 1 })
@@ -17,7 +16,7 @@ g_coRouter.use(g_csRoot + "in", function(a_oRequest, a_oResponse) {
 		a_oResponse.status(g_codes.get("Invalid")).redirect("/Authentication.htm")
 	})
 })
-g_coRouter.use(g_csRoot + "out", function(a_oRequest, a_oResponse) {
+g_coRouter.use("/out", function(a_oRequest, a_oResponse) {
 	a_oRequest.session.destroy(function(a_oError) {
 		if (a_oError) return a_oResponse.sendStatus(g_codes.get("Server error"))
 		a_oResponse.clearCookie("connect.sid")

--- a/code/backend/server/ShutDown.cts
+++ b/code/backend/server/ShutDown.cts
@@ -1,6 +1,6 @@
 const g_cToggleProcessing = require("../utilities/processing.cts")
 
-module.exports = Array.of(
+module.exports = new Set(Array.of(
 	async function() {
 		g_cToggleProcessing("Attempting to disconnect from database.")
 		try {
@@ -28,4 +28,4 @@ module.exports = Array.of(
 			console.log("Successfully shut down server.")
 		}
 	}
-)
+))

--- a/code/backend/server/auth.cts
+++ b/code/backend/server/auth.cts
@@ -1,3 +1,1 @@
-module.exports = function(a_oRequest, a_oResponse, a_Next) {
-	return a_oRequest.session.data.user ? a_Next() : a_oResponse.redirect("/Authentication.htm")
-}
+module.exports = (a_oRequest, a_oResponse, a_Next) => a_oRequest.session.data.user ? a_Next() : a_oResponse.redirect("/Authentication.htm")

--- a/code/backend/server/endpoints.cts
+++ b/code/backend/server/endpoints.cts
@@ -1,6 +1,5 @@
 require("dotenv").config()
 const g_cExpress = require("express")
-const g_csRoot = require("../utilities/root.cts")
 const g_cAuth = require("./auth.cts")
 const g_codes = require("./data.cts").get("Status codes")
 
@@ -15,14 +14,14 @@ g_coApp.use(require("express-session")({
 	saveUninitialized: true,
 	secret: process.env.SECRET
 }))
-g_coApp.use(g_csRoot + "log", require("../queries/logging.cts"))
+g_coApp.use("/" + "log", require("../queries/logging.cts"))
 
-g_coApp.use(g_csRoot + "event", g_cAuth, require("../queries/EventOps.cts"))
-g_coApp.use(g_csRoot + "inviation", g_cAuth, require("../queries/InvitationOps.cts"))
-g_coApp.use(g_csRoot + "message", g_cAuth, require("../queries/MesOps.cts"))
-g_coApp.use(g_csRoot + "request", g_cAuth, require("../queries/RequestOps.cts"))
-g_coApp.use(g_csRoot + "notification", g_cAuth, require("../queries/NotifOps.cts"))
-g_coApp.use(g_csRoot + "user", require("../queries/UserOps.cts"))
+g_coApp.use("/" + "event", g_cAuth, require("../queries/EventOps.cts"))
+g_coApp.use("/" + "inviation", g_cAuth, require("../queries/InvitationOps.cts"))
+g_coApp.use("/" + "message", g_cAuth, require("../queries/MesOps.cts"))
+g_coApp.use("/" + "request", g_cAuth, require("../queries/RequestOps.cts"))
+g_coApp.use("/" + "notification", g_cAuth, require("../queries/NotifOps.cts"))
+g_coApp.use("/" + "user", require("../queries/UserOps.cts"))
 
 g_coApp.use(g_cExpress.static(require("path").join(__dirname, "code/frontend"), { index: "HomePage.htm" }))
 g_coApp.use(g_cAuth, g_cExpress.static(require("path").join(__dirname, "code/frontend/auth"), { index: "DashBoard.htm" }))

--- a/code/backend/utilities/converter.cts
+++ b/code/backend/utilities/converter.cts
@@ -1,2 +1,0 @@
-module.exports = new Map(Array.of(
-	Array.of("String to object ID", (a_string) => new (require("mongodb").ObjectId)(a_string))))

--- a/code/backend/utilities/converters.cts
+++ b/code/backend/utilities/converters.cts
@@ -1,0 +1,3 @@
+const g_cObjectId = require("mongodb").ObjectId
+
+module.exports = new Map(Array.of((Array.of(Symbol.for(Array.of(String, g_cObjectId)), (a_sId) => new g_cObjectId(a_sId))))

--- a/code/backend/utilities/root.cts
+++ b/code/backend/utilities/root.cts
@@ -1,1 +1,0 @@
-module.exports = "/"

--- a/code/backend/validators/event.cts
+++ b/code/backend/validators/event.cts
@@ -3,13 +3,13 @@ module.exports = {
 		$jsonSchema: {
 			bsonType: "object",
 			description: "An event.",
-			required: Array.of("public", "organiser"),
+			required: Array.of("Public", "Organiser"),
 			properties: {
-				public: {
+				Public: {
 					bsonType: "bool",
 					description: "Whether or not the event is public."
 				},
-				invitations: {
+				Invitations: {
 					bsonType: "array",
 					description: "The invitations to the event.",
 					uniqueItems: true,
@@ -18,7 +18,7 @@ module.exports = {
 						description: "An invitation to the event."
 					}
 				},
-				requests: {
+				Requests: {
 					bsonType: "array",
 					description: "The requests to join the event.",
 					uniqueItems: true,
@@ -27,7 +27,7 @@ module.exports = {
 						description: "A request to join the event."
 					}
 				},
-				DiscussionBoard: {
+				"Disscussion board": {
 					bsonType: "array",
 					description: "The discussion board of the event.",
 					uniqueItems: true,
@@ -36,7 +36,7 @@ module.exports = {
 						description: "A message in the discussion board."
 					}
 				},
-				notifications: {
+				Notifications: {
 					bsonType: "array",
 					description: "Notifications for the event.",
 					uniqueItems: true,
@@ -45,7 +45,7 @@ module.exports = {
 						description: "A notification for the event."
 					}
 				},
-				images: {
+				Images: {
 					bsonType: "array",
 					description: "Images of the event.",
 					items: {
@@ -53,7 +53,7 @@ module.exports = {
 						description: "An image of the event."
 					}
 				},
-				organiser: {
+				"Organiser ID": {
 					bsonType: "objectId",
 					description: "The organiser of the event."
 				}

--- a/code/backend/validators/invitation.cts
+++ b/code/backend/validators/invitation.cts
@@ -3,18 +3,18 @@ module.exports = {
 		$jsonSchema: {
 			bsonType: "object",
 			description: "An invitation to an event.",
-			required: Array.of("receiver", "state", "event"),
+			required: Array.of("Receiver ID", "State", "Event ID"),
 			properties: {
-				receiver: {
+				"Receiver ID": {
 					bsonType: "objectId",
 					description: "The user invited to the event."
 				},
-				state: {
+				State: {
 					bsonType: "string",
 					enum: Array.of("Accepted", "Not responded", "Declined"),
 					description: "The current state of the invitation."
 				},
-				event: {
+				"Event ID": {
 					bsonType: "objectId",
 					description: "The event."
 				}

--- a/code/backend/validators/message.cts
+++ b/code/backend/validators/message.cts
@@ -3,17 +3,17 @@ module.exports = {
 		$jsonSchema: {
 			bsonType: "object",
 			description: "A message in the discussion board of an event.",
-			required: Array.of("sender, event"),
+			required: Array.of("Sender ID", "Event ID"),
 			properties: {
-				text: {
+				Text: {
 					bsonType: "string",
 					description: "The contents of the message.",
 				},
-				sender: {
+				"Sender ID": {
 					bsonType: "objectId",
 					description: "The user who sent the message."
 				},
-				event: {
+				"Event ID": {
 					bsonType: "objectId",
 					description: "The event whose discussion board contains the message."
 				}

--- a/code/backend/validators/notification.cts
+++ b/code/backend/validators/notification.cts
@@ -3,13 +3,13 @@ module.exports = {
 		$jsonSchema: {
 			bsonType: "object",
 			description: "The notification related to an event.",
-			required: Array.of("reminder", "event"),
+			required: Array.of("Reminder", "Event ID"),
 			properties: {
-				text: {
+				Text: {
 					bsonType: "string",
 					description: "The notification text.",
 				},
-				reminder: {
+				Reminder: {
 					bsonType: "bool",
 					description: "Whether or the notification is a reminder."
 				},
@@ -17,7 +17,7 @@ module.exports = {
 					bsonType: "timestamp",
 					description: "The time at which the notification is sent.",
 				},
-				event: {
+				"Event ID": {
 					bsonType: "objectId",
 					description: "The event."
 				}

--- a/code/backend/validators/request.cts
+++ b/code/backend/validators/request.cts
@@ -3,18 +3,18 @@ module.exports = {
 		$jsonSchema: {
 			bsonType: "object",
 			description: "A request to join an event.",
-			required: Array.of("sender, state, event"),
+			required: Array.of("Sender ID", "State", "Event ID"),
 			properties: {
-				sender: {
+				"Sender ID": {
 					bsonType: "objectId",
 					description: "The user who sent the request.",
 				},
-				state: {
+				State: {
 					bsonType: "string",
 					enum: Array.of("Accepted", "Unanswered", "Rejected"),
 					description: "The state of the request."
 				},
-				event: {
+				"Event ID": {
 					bsonType: "objectId",
 					description: "The event to join."
 				}

--- a/code/backend/validators/session.cts
+++ b/code/backend/validators/session.cts
@@ -7,13 +7,13 @@ module.exports = {
 			properties: {
 				data: {
 					bsonType: "object",
-					required: Array.of("active"),
+					required: Array.of("Active"),
 					properties: {
-						active: {
+						Active: {
 							bsonType: "bool",
 							description: "Whether the session is active.",
 						},
-						user: {
+						"User ID": {
 							bsonType: "objectId",
 							description: "The user associated with the session.",
 						}

--- a/code/backend/validators/user.cts
+++ b/code/backend/validators/user.cts
@@ -3,13 +3,13 @@ module.exports = {
 		$jsonSchema: {
 			bsonType: "object",
 			description: "A user.",
-			required: Array.of("username", "Maximum number of active events", "Maximum number of invitations to an event", "admin"),
+			required: Array.of("Username", "Maximum number of active events", "Maximum number of invitations to an event", "Admin"),
 			properties: {
-				username: {
+				Username: {
 					bsonType: "string",
 					description: "The username of a user."
 				},
-				password: {
+				Password: {
 					bsonType: "string",
 					description: "The hashed password of a user."
 				},
@@ -17,7 +17,7 @@ module.exports = {
 					bsonType: "string",
 					description: "The email address of a user."
 				},
-				notifications: {
+				Notifications: {
 					bsonType: "array",
 					description: "The notifications the user has received.",
 					uniqueItems: true,
@@ -43,11 +43,11 @@ module.exports = {
 					bsonType: "long",
 					description: "The maximum number of invitations to an event the user can send."
 				},
-				admin: {
+				Admin: {
 					bsonType: "bool",
 					description: "Whether the user is an admin."
 				},
-				sessions: {
+				Sessions: {
 					bsonType: "array",
 					description: "The sessions of the user.",
 					uniqueItems: true,


### PR DESCRIPTION
This pull request includes several changes aimed at simplifying and standardizing the codebase, particularly around the use of root paths and schema definitions.

### Standardization of Root Paths:

* [`code/backend/queries/EventOps.cts`](diffhunk://#diff-be8f06d396218164992d9fc041980888d8605fedc73263a3116f5ddd60639de2L2-R14): Replaced `g_csRoot` with `"/"` in all routes.
* [`code/backend/queries/InvitationOps.cts`](diffhunk://#diff-a13db97dded38f3e4f7a1c9f093947c0935a87394ab6ad16362a213b7e67fe1cL2-R14): Replaced `g_csRoot` with `"/"` in all routes.
* [`code/backend/queries/MesOps.cts`](diffhunk://#diff-8087ce5194471f095b97e4f1191f8a775b483843ab3b4035cad25838a3ad7e57L2-R14): Replaced `g_csRoot` with `"/"` in all routes.
* [`code/backend/queries/NotifOps.cts`](diffhunk://#diff-fa216824a9d4ea1b8b350055c07e07d71c7043c2731164cc602525fe528a17d4L2-R14): Replaced `g_csRoot` with `"/"` in all routes.
* [`code/backend/queries/UserOps.cts`](diffhunk://#diff-8e7452f807763d80227be1239632f641cdeb128bc9914cecfd2bb1b84fa06abbL2-R15): Replaced `g_csRoot` with `"/"` in all routes.
* [`code/backend/queries/logging.cts`](diffhunk://#diff-457343ae64f2463441062ffdf06ceb6bcaaa54bf50343cbc67cf4f06f28d3558L2-R5): Replaced `g_csRoot` with `"/"` in all routes. [[1]](diffhunk://#diff-457343ae64f2463441062ffdf06ceb6bcaaa54bf50343cbc67cf4f06f28d3558L2-R5) [[2]](diffhunk://#diff-457343ae64f2463441062ffdf06ceb6bcaaa54bf50343cbc67cf4f06f28d3558L20-R19)
* [`code/backend/server/endpoints.cts`](diffhunk://#diff-edcf07263dde6e3f052890d42ddae4b2505adf49aa7ef77b8d8beec8664d6c55L3): Replaced `g_csRoot` with `"/"` in all routes. [[1]](diffhunk://#diff-edcf07263dde6e3f052890d42ddae4b2505adf49aa7ef77b8d8beec8664d6c55L3) [[2]](diffhunk://#diff-edcf07263dde6e3f052890d42ddae4b2505adf49aa7ef77b8d8beec8664d6c55L18-R24)

### Schema Definition Updates:

* [`code/backend/validators/event.cts`](diffhunk://#diff-873e51b2133fbad85824a563787909da67df9e5a16e0a4b248e61a6e138dd706L6-R12): Updated property names to use PascalCase and corrected a typo in `DiscussionBoard`. [[1]](diffhunk://#diff-873e51b2133fbad85824a563787909da67df9e5a16e0a4b248e61a6e138dd706L6-R12) [[2]](diffhunk://#diff-873e51b2133fbad85824a563787909da67df9e5a16e0a4b248e61a6e138dd706L21-R21) [[3]](diffhunk://#diff-873e51b2133fbad85824a563787909da67df9e5a16e0a4b248e61a6e138dd706L30-R30) [[4]](diffhunk://#diff-873e51b2133fbad85824a563787909da67df9e5a16e0a4b248e61a6e138dd706L39-R39) [[5]](diffhunk://#diff-873e51b2133fbad85824a563787909da67df9e5a16e0a4b248e61a6e138dd706L48-R56)
* [`code/backend/validators/invitation.cts`](diffhunk://#diff-61ef351abb5b289cbec4481a1e34278f346e7d163dd776021e88e2507ea5f70eL6-R17): Updated property names to use PascalCase.
* [`code/backend/validators/message.cts`](diffhunk://#diff-be51e3dcf8d46bb72a0dd875a78f03c6d1efc93ae3a4ae8b1120bda97d0bed65L6-R16): Updated property names to use PascalCase.
* [`code/backend/validators/notification.cts`](diffhunk://#diff-3b01d9899f1c08ae966976815ebf7baa17c0f9daacc86f6519f089f3774e4e6bL6-R20): Updated property names to use PascalCase.
* [`code/backend/validators/request.cts`](diffhunk://#diff-8cfff0a2ecfb020c54eb72642d94732360029a95eba09351b36349f9ba583ccaL6-R17): Updated property names to use PascalCase.
* [`code/backend/validators/session.cts`](diffhunk://#diff-3b74673e3990d917ffb127c9d8ba1a4bcf7b0e35e618a457c45a1cdffe80b0bdL10-R16): Updated property names to use PascalCase.
* [`code/backend/validators/user.cts`](diffhunk://#diff-29b5c7abe78f6f3b52d39dae36e19657f16238b89b55d170382b11307f36cc02L6-R20): Updated property names to use PascalCase. [[1]](diffhunk://#diff-29b5c7abe78f6f3b52d39dae36e19657f16238b89b55d170382b11307f36cc02L6-R20) [[2]](diffhunk://#diff-29b5c7abe78f6f3b52d39dae36e19657f16238b89b55d170382b11307f36cc02L46-R50)

### Code Simplification:

* [`code/backend/server/ShutDown.cts`](diffhunk://#diff-52a43bffbf594e6fe54a5d0e5b17f1673e2a8f53e96ce01f3b7e1e47d28f182eL3-R3): Changed `module.exports` from an array to a set for better performance. [[1]](diffhunk://#diff-52a43bffbf594e6fe54a5d0e5b17f1673e2a8f53e96ce01f3b7e1e47d28f182eL3-R3) [[2]](diffhunk://#diff-52a43bffbf594e6fe54a5d0e5b17f1673e2a8f53e96ce01f3b7e1e47d28f182eL31-R31)
* [`code/backend/server/auth.cts`](diffhunk://#diff-443d5463e540724f59185fba8b6e80829e139c5a0b2c9cadd768bf2d786878bdL1-R1): Simplified the function export to use an arrow function.
* [`code/backend/utilities/converter.cts`](diffhunk://#diff-f34a96f830ef260c6e64252281a5042441b49f033a49e49559185309aa8706cdL1-L2): Removed the old converter module.
* [`code/backend/utilities/converters.cts`](diffhunk://#diff-52f09892f3aba9037bf458c66b5037d73902fa3daa9a29a14ba0d0e5564f28c3R1-R3): Added a new converter module with updated mappings.
* [`code/backend/utilities/root.cts`](diffhunk://#diff-efdb6320e21d0fa02226c375fa591cca5e148e417d33f5f265360fcb8b870abfL1): Removed the root module as it is no longer needed.