### PR TITLE
Add a lot of things, with no changes to the schema (which currently my only issue is probably just a better naming scheme, it is confusing)

### DIFF
--- a/backend/model/request.ts
+++ b/backend/model/request.ts
@@ -18,6 +18,10 @@ export default {
 				eventId: {
 					bsonType: "objectId",
 					title: "The event to join."
+				},
+				receiverId: {
+					bsonType: "objectId",
+					title: "The event to join."
 				}
 			},
 			additionalProperties: false

--- a/backend/model/user.ts
+++ b/backend/model/user.ts
@@ -66,7 +66,7 @@ export default {
 				},
 				requests: {
 					bsonType: "array",
-					title: "All public requests the user has requested",
+					title: "All public requests the user has received",
 					uniqueItems: true,
 					items: {
 						bsonType: "objectId",

--- a/backend/queries/EventOps.ts
+++ b/backend/queries/EventOps.ts
@@ -111,6 +111,19 @@ g_coRouter.get("/owned", async function(a_oRequest, a_oResponse) {
 	}
 })
 
+g_coRouter.get("/joined", async function(a_oRequest, a_oResponse) {
+	try {
+		const userId = a_oRequest.session["User ID"]
+
+		const l_aEvents = await g_coEvents.find({ joinedUsers: userId }).toArray()
+
+		a_oResponse.status(g_codes("Success")).json(l_aEvents)
+	} catch (err) {
+		console.error("Failed to fetch events:", err)
+		a_oResponse.status(g_codes("Server error"))
+	}
+})
+
 g_coRouter.get("/image/:id", async function(a_oRequest, a_oResponse) {
     try {
 		const l_oId = new ObjectId(a_oRequest.params.id)

--- a/backend/queries/InvitationOps.ts
+++ b/backend/queries/InvitationOps.ts
@@ -15,6 +15,22 @@ g_coRouter.post("/", function(a_oRequest, a_oResponse) {
 g_coRouter.get("/", function(a_oRequest, a_oResponse) {
 	
 })
+
+g_coRouter.get("/received", async function(a_oRequest, a_oResponse) {
+    try {
+        const userId = a_oRequest.session["User ID"]
+
+        const l_aResponse = await g_coInvitations.find({
+            receiverId: userId,
+        }).toArray();
+
+        a_oResponse.status(g_codes("Success")).json(l_aResponse)
+    } catch (a_oError) {
+        console.log(a_oError)
+        return a_oResponse.status(g_codes("Server error")).json(a_oError)
+    }
+})
+
 g_coRouter.put("/", function(a_oRequest, a_oResponse) {
 	
 })

--- a/backend/queries/RequestOps.ts
+++ b/backend/queries/RequestOps.ts
@@ -54,6 +54,21 @@ g_coRouter.get("/", g_cookieParser(), async function(a_oRequest, a_oResponse) {
 		return a_oResponse.status(g_codes("Server error")).json(a_oError)
 	}
 })
+g_coRouter.get("/sent", async function(a_oRequest, a_oResponse) {
+	try {
+		const userId = a_oRequest.session["User ID"]
+
+		const l_aResponse = await g_coRequests.find({
+			senderId: userId,
+		}).toArray();
+
+		a_oResponse.status(g_codes("Success")).json(l_aResponse)
+	} catch (a_oError) {
+		console.log(a_oError)
+		return a_oResponse.status(g_codes("Server error")).json(a_oError)
+	}
+})
+
 g_coRouter.put("/", function(a_oRequest, a_oResponse) {
 	
 })

--- a/backend/queries/UserOps.ts
+++ b/backend/queries/UserOps.ts
@@ -84,6 +84,17 @@ g_coRouter.get("/", async function(req, res) {
 	}
 })
 
+g_coRouter.get("/:id", async function(req, res) {
+	try {
+		const result = await g_coUsers.findOne({
+			_id: req.params.id,
+		})
+		res.status(g_codes("Success")).json(result);
+	} catch (error) {
+		res.status(g_codes("Server error")).json(error)
+	}
+})
+
 // GET Route for avatar
 g_coRouter.get("/image/:id", async function(a_oRequest, a_oResponse) {
     try {

--- a/frontend/src/components/Navigation/Sidebar.tsx
+++ b/frontend/src/components/Navigation/Sidebar.tsx
@@ -34,11 +34,6 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen }) => {
           <span>Event Management</span>
         </Link>
 
-        <Link to="/joined-events" className="flex items-center space-x-3 px-4 py-3 text-gray-800 hover:bg-[#f7dc6f] rounded-lg transition-colors">
-          <CalendarIcon className="h-6 w-6" />
-          <span>Joined Events</span>
-        </Link>
-
         <Link to="/rsvp-responses" className="flex items-center space-x-3 px-4 py-3 text-gray-800 hover:bg-[#f7dc6f] rounded-lg transition-colors">
           <ClipboardDocumentListIcon className="h-6 w-6" />
           <span>RSVP Responses</span>

--- a/frontend/src/dataTypes/type.ts
+++ b/frontend/src/dataTypes/type.ts
@@ -27,3 +27,29 @@ export type Event = {
     eventTime: Date;
     joinedUsers: string[];
 };
+
+export type Request = {
+    _id: string;
+    senderId: string;
+    state: RequestStatus,
+    eventId: string;
+}
+
+export type Invitation = {
+    _id: string;
+    receiverId: string;
+    state: InvitationStatus,
+    eventId: string;
+}
+
+export enum RequestStatus {
+    Accepted = "Accepted",
+    Unanswered = "Unanswered",
+    Rejected = "Rejected",
+}
+
+export enum InvitationStatus {
+    Accepted = "Accepted",
+    NotResponded = "Not responded",
+    Declined = "Declined"
+}

--- a/frontend/src/features/RSVP/ReceivedCard.tsx
+++ b/frontend/src/features/RSVP/ReceivedCard.tsx
@@ -1,0 +1,56 @@
+import {InvitationStatus} from "../../dataTypes/type.ts";
+import {useDispatch} from "react-redux";
+import {AppDispatch} from "../../redux/store.ts";
+import {useAppSelector} from "../../hook/hooks.ts";
+import {useEffect} from "react";
+import {fetchSingleEvent} from "../../redux/event/singleEventSlice.ts";
+import {Link} from "react-router-dom";
+
+interface InvitationCardProps {
+    eventId: string,
+    status: InvitationStatus,
+}
+
+export default function ReceivedCard({eventId, status}: InvitationCardProps) {
+    const dispatch = useDispatch<AppDispatch>();
+    const currentEvent = useAppSelector(state => state.singleEvent.event);
+
+    useEffect(() => {
+        dispatch(fetchSingleEvent(eventId));
+    }, [eventId, dispatch]);
+
+    if (!currentEvent) {
+        return <h1>No invitation received sent</h1>;
+    }
+
+    return (
+        <div className="flex items-center gap-4 bg-white shadow-md rounded-2xl p-4 my-6 w-full max-w-xl">
+            <Link to={`/event-detail/${eventId}`} className="flex items-center gap-4 flex-grow">
+                <img
+                    src={`/event/image/${currentEvent.images}`}
+                    alt={currentEvent.eventName}
+                    className="w-16 h-16 object-cover rounded-xl"
+                />
+                <div className="flex flex-col">
+                    <span className="text-lg font-semibold">{currentEvent.eventName}</span>
+                    <span className="text-sm font-medium">{status}</span>
+                </div>
+            </Link>
+
+            {status == InvitationStatus.NotResponded && (
+                <div className="flex gap-2">
+                    <button
+                        className="px-3 py-1 text-sm cursor-pointer bg-green-500 text-white rounded-lg hover:bg-green-600"
+                    >
+                        Accept
+                    </button>
+                    <button
+                        className="px-3 py-1 text-sm cursor-pointer bg-red-500 text-white rounded-lg hover:bg-red-600"
+                    >
+                        Reject
+                    </button>
+                </div>
+            )}
+        </div>
+    )
+}

--- a/frontend/src/features/RSVP/SentCard.tsx
+++ b/frontend/src/features/RSVP/SentCard.tsx
@@ -1,0 +1,41 @@
+import {RequestStatus} from "../../dataTypes/type.ts";
+import {useDispatch} from "react-redux";
+import {AppDispatch} from "../../redux/store.ts";
+import {useAppSelector} from "../../hook/hooks.ts";
+import {useEffect} from "react";
+import {fetchSingleEvent} from "../../redux/event/singleEventSlice.ts";
+import {Link} from "react-router-dom";
+
+interface SentCardProps {
+    eventId: string,
+    status: RequestStatus,
+}
+
+export default function SentCard({eventId, status}: SentCardProps) {
+    const dispatch = useDispatch<AppDispatch>();
+    const currentEvent = useAppSelector(state => state.singleEvent.event);
+
+    useEffect(() => {
+        dispatch(fetchSingleEvent(eventId));
+    }, [eventId, dispatch]);
+
+    if (!currentEvent) {
+        return <h1>No request sent</h1>;
+    }
+
+    return (
+        <Link to={`/event-detail/${eventId}`} className="flex items-center gap-4 bg-white shadow-md rounded-2xl p-4 my-6 w-full max-w-xl">
+            <img
+                src={`/event/image/${currentEvent.images}`}
+                alt={currentEvent.eventName}
+                className="w-16 h-16 object-cover rounded-xl"
+            />
+            <div className="flex flex-col flex-grow">
+                <span className="text-lg font-semibold">{currentEvent.eventName}</span>
+                <span className={`text-sm font-medium`}>
+                    {status}
+                </span>
+            </div>
+        </Link>
+    )
+}

--- a/frontend/src/features/eventManagement/EventManagenentCard.tsx
+++ b/frontend/src/features/eventManagement/EventManagenentCard.tsx
@@ -23,7 +23,6 @@ const EventManagementCard: FC<EventManagementCardProps> = ({
     eventLocation,
 }) => {
     return (
-        
         <Link to={`/event-detail/${_id}`} className="flex justify-around w-full gap-3">
             {/* Image Section */}
             <div className="w-60 h-40 overflow-hidden rounded-lg bg-gray-100">

--- a/frontend/src/features/publicEvents/EventCard.tsx
+++ b/frontend/src/features/publicEvents/EventCard.tsx
@@ -17,12 +17,11 @@ const EventCard: FC<EventCardProps> = ({
     owned
 }) => {
     return (
-        <>
-        <Link to={`/event-detail/${_id}?owned=${owned}`} className="w-[260px] rounded-xl overflow-hidden bg-white shadow-sm cursor-pointer transition-transform duration-200 hover:shadow-md hover:scale-[1.02]">
+        <Link to={`/event-detail/${_id}?owned=${owned}`} className="w-[328px] rounded-xl overflow-hidden bg-white shadow-sm cursor-pointer transition-transform duration-200 hover:shadow-md hover:scale-[1.02]">
             <img
                 src={`/event/image/${images}`}
                 alt={eventName}
-                className="w-full h-[160px] object-cover rounded-t-xl"
+                className="w-full object-cover rounded-t-xl"
             />
             <div className="p-3 space-y-1">
                 <div className="flex items-start gap-2">
@@ -41,7 +40,6 @@ const EventCard: FC<EventCardProps> = ({
                 )}
             </div>
         </Link>
-        </>
     )
 };
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,1 +1,8 @@
 @import "tailwindcss";
+/* index.css */
+body {
+    background-color: oklch(96.2% 0.059 95.617); /* This is similar to Tailwind's bg-gray-100 */
+    margin: 0;
+    padding: 0;
+    font-family: 'Inter', sans-serif; /* optional, for consistent look */
+}

--- a/frontend/src/pages/CreateEventPage.tsx
+++ b/frontend/src/pages/CreateEventPage.tsx
@@ -4,7 +4,7 @@ import {useAppDispatch, useAppSelector} from "../hook/hooks.ts";
 import {toggle} from "../redux/components/sidebarSlice.ts";
 import CreateEventCard from "../features/createEvents/CreateEventCard.tsx";
 
-export default function CreateEvent() {
+export default function CreateEventPage() {
     const dispatch = useAppDispatch();
 
     const isSidebarOpen = useAppSelector(state => state.sidebar.isOpen)
@@ -14,7 +14,7 @@ export default function CreateEvent() {
         <div>
             <Navbar toggleSidebar={toggleSidebar} />
             <Sidebar isOpen={isSidebarOpen} />
-            <div className={`mt-20 ${isSidebarOpen ? 'ml-72' : 'ml-8'}`}>
+            <div className={`mt-20 transition-all duration-300 ${isSidebarOpen ? 'ml-72' : 'ml-8'}`}>
                 <CreateEventCard />
             </div>
         </div>

--- a/frontend/src/pages/EventManagementPage.tsx
+++ b/frontend/src/pages/EventManagementPage.tsx
@@ -7,23 +7,28 @@ import {toggle} from "../redux/components/sidebarSlice.ts";
 import Sidebar from "../components/Navigation/Sidebar.tsx";
 import Navbar from "../components/Navigation/Navbar.tsx";
 import EventManagementCard from "../features/eventManagement/EventManagenentCard.tsx";
+import {fetchJoinedEvents} from "../redux/event/joinedEventSlice.ts";
 
 export default function EventManagementPage() {
     const isSidebarOpen = useAppSelector(state => state.sidebar.isOpen)
     const dispatch = useDispatch<AppDispatch>();
 
-    const events = useAppSelector(state => state.ownedEvents.events);
-    const error = useAppSelector(state => state.ownedEvents.error);
+    const ownedEvents = useAppSelector(state => state.ownedEvents.events);
+    const ownedError = useAppSelector(state => state.ownedEvents.error);
+
+    const joinedEvents = useAppSelector(state => state.joinedEvents.events);
+    const joinedError = useAppSelector(state => state.joinedEvents.error);
 
     useEffect(() => {
         dispatch(fetchOwnedEvents());
+        dispatch(fetchJoinedEvents());
     }, [dispatch]);
 
-    if (error) {
-        return <div>Error: {error}</div>;
+    if (ownedError || joinedError) {
+        return <div>Error: {ownedError || joinedError}</div>;
     }
 
-    console.log(events);
+    console.log(ownedEvents);
 
     const toggleSidebar = () => dispatch(toggle())
 
@@ -32,25 +37,47 @@ export default function EventManagementPage() {
             <Sidebar isOpen={isSidebarOpen} />
             <div>
                 <Navbar toggleSidebar={toggleSidebar} />
-                <div className={`mt-20 ml-10 flex flex-wrap gap-10 ${isSidebarOpen ? 'ml-72' : 'ml-8'}`}>
-                    <h1 className="font-bold text-2xl">Owned Events</h1>
-                    {events.map(event => {
-                        return (
-                            <EventManagementCard
-                                key={event._id}
-                                _id={event._id}
-                                eventName={event.eventName}
-                                eventDescription={event.eventDescription}
-                                images={event.images}
-                                isPublic={event.public}
-                                eventLocation={event.eventLocation}
-                                eventTime={event.eventTime}
-                                joinedUsers={event.joinedUsers}
+                <div className={`mt-20 ml-10 flex flex-col gap-y-4 transition-all duration-300 ${isSidebarOpen ? 'ml-72' : 'ml-8'}`}>
+                    <div className="flex flex-col gap-y-4">
+                        <h1 className="font-bold text-3xl">Owned Events</h1>
+                        {ownedEvents.map(event => {
+                            return (
+                                <EventManagementCard
+                                    key={event._id}
+                                    _id={event._id}
+                                    eventName={event.eventName}
+                                    eventDescription={event.eventDescription}
+                                    images={event.images}
+                                    isPublic={event.public}
+                                    eventLocation={event.eventLocation}
+                                    eventTime={event.eventTime}
+                                    joinedUsers={event.joinedUsers}
 
-                            />
-                        )
-                    })
-                    }
+                                />
+                            )
+                        })
+                        }
+                    </div>
+                    <div className="flex flex-col gap-y-4">
+                        <h1 className="font-bold text-2xl">Joined Events</h1>
+                        {joinedEvents.map(event => {
+                            return (
+                                <EventManagementCard
+                                    key={event._id}
+                                    _id={event._id}
+                                    eventName={event.eventName}
+                                    eventDescription={event.eventDescription}
+                                    images={event.images}
+                                    isPublic={event.public}
+                                    eventLocation={event.eventLocation}
+                                    eventTime={event.eventTime}
+                                    joinedUsers={event.joinedUsers}
+
+                                />
+                            )
+                        })
+                        }
+                    </div>
                 </div>
             </div>
         </div>

--- a/frontend/src/pages/PublicEventPage.tsx
+++ b/frontend/src/pages/PublicEventPage.tsx
@@ -10,7 +10,7 @@ import {fetchPublicEvents} from "../redux/event/publicEventSlice.ts";
 import {fetchOwnedEvents} from "../redux/event/ownedEventsSlice.ts";
 
 
-export default function PublicEvents() {
+export default function PublicEventPage() {
     const isSidebarOpen = useAppSelector(state => state.sidebar.isOpen)
     const dispatch = useDispatch<AppDispatch>();
 
@@ -36,7 +36,7 @@ export default function PublicEvents() {
             <Sidebar isOpen={isSidebarOpen} />
             <div>
                 <Navbar toggleSidebar={toggleSidebar} />
-                <div className="mt-20 ml-10 flex flex-wrap gap-10">
+                <div className={`mt-20 flex flex-wrap transition-all duration-300  gap-13 ${isSidebarOpen ? 'ml-80' : 'ml-9'}`}>
                     {events.map(event => {
                         return (
                             <EventCard

--- a/frontend/src/pages/RSVPChildrenPages/ReceivedInvitationsPage.tsx
+++ b/frontend/src/pages/RSVPChildrenPages/ReceivedInvitationsPage.tsx
@@ -1,0 +1,40 @@
+import {useAppDispatch, useAppSelector} from "../../hook/hooks.ts";
+import {toggle} from "../../redux/components/sidebarSlice.ts";
+import Navbar from "../../components/Navigation/Navbar.tsx";
+import Sidebar from "../../components/Navigation/Sidebar.tsx";
+import {useEffect} from "react";
+import {fetchReceivedInvitations} from "../../redux/RSVP/receivedInvitationsSlice.ts";
+import ReceivedCard from "../../features/RSVP/ReceivedCard.tsx";
+
+export default function ReceivedInvitationsPage() {
+    const dispatch = useAppDispatch();
+
+    const isSidebarOpen = useAppSelector(state => state.sidebar.isOpen)
+    const toggleSidebar = () => dispatch(toggle())
+
+    const receivedInvitations = useAppSelector(state => state.receivedInvitations.invitations);
+    const error = useAppSelector(state => state.receivedInvitations.error);
+
+    useEffect(() => {
+        dispatch(fetchReceivedInvitations());
+    }, [dispatch]);
+
+    if (error) {
+        return <div>Error: {error}</div>;
+    }
+
+    return (
+        <div>
+            <Navbar toggleSidebar={toggleSidebar} />
+            <Sidebar isOpen={isSidebarOpen} />
+            <div className={`mt-20 transition-all duration-300 ${isSidebarOpen ? 'ml-72' : 'ml-8'}`}>
+                <h1 className="font-bold text-3xl">Received Invitations</h1>
+                {receivedInvitations.map((invitation) => {
+                    return (
+                        <ReceivedCard eventId={invitation.eventId} status={invitation.state} />
+                    )
+                })}
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/pages/RSVPChildrenPages/SentRequestsPage.tsx
+++ b/frontend/src/pages/RSVPChildrenPages/SentRequestsPage.tsx
@@ -1,0 +1,40 @@
+import {useAppDispatch, useAppSelector} from "../../hook/hooks.ts";
+import {toggle} from "../../redux/components/sidebarSlice.ts";
+import Navbar from "../../components/Navigation/Navbar.tsx";
+import Sidebar from "../../components/Navigation/Sidebar.tsx";
+import {useEffect} from "react";
+import {fetchSentRequests} from "../../redux/RSVP/sentRequestsSlice.ts";
+import SentCard from "../../features/RSVP/SentCard.tsx";
+
+export default function SentRequestsPage() {
+    const dispatch = useAppDispatch();
+
+    const isSidebarOpen = useAppSelector(state => state.sidebar.isOpen)
+    const toggleSidebar = () => dispatch(toggle())
+
+    const sentRequests = useAppSelector(state => state.sentRequests.requests);
+    const error = useAppSelector(state => state.sentRequests.error);
+    
+    useEffect(() => {
+        dispatch(fetchSentRequests());
+    }, [dispatch]);
+
+    if (error) {
+        return <div>Error: {error}</div>;
+    }
+
+    return (
+        <div>
+            <Navbar toggleSidebar={toggleSidebar} />
+            <Sidebar isOpen={isSidebarOpen} />
+            <div className={`mt-20 transition-all duration-300 ${isSidebarOpen ? 'ml-72' : 'ml-8'}`}>
+                <h1 className="font-bold text-3xl">Sent Requests</h1>
+                {sentRequests.map((request) => {
+                    return (
+                        <SentCard eventId={request.eventId} status={request.state} />
+                    )
+                })}
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/pages/RSVPResponsePage.tsx
+++ b/frontend/src/pages/RSVPResponsePage.tsx
@@ -1,0 +1,33 @@
+import {useAppDispatch, useAppSelector} from "../hook/hooks.ts";
+import {toggle} from "../redux/components/sidebarSlice.ts";
+import Navbar from "../components/Navigation/Navbar.tsx";
+import Sidebar from "../components/Navigation/Sidebar.tsx";
+import {Link} from "react-router-dom";
+
+export default function RSVPResponsePage() {
+    const dispatch = useAppDispatch();
+
+    const isSidebarOpen = useAppSelector(state => state.sidebar.isOpen)
+    const toggleSidebar = () => dispatch(toggle())
+
+    return (
+        <div className="h-screen flex flex-col">
+            <Navbar toggleSidebar={toggleSidebar} />
+            <div className="flex flex-1">
+                <Sidebar isOpen={isSidebarOpen} />
+                <div className={`transition-all duration-300 w-full ${isSidebarOpen ? 'ml-64' : 'ml-0'}`}>
+                    <div className="flex items-center justify-center h-full">
+                        <div className="flex flex-col space-y-4 w-64">
+                            <Link to="/rsvp-responses/sent-requests">
+                                <button className="w-full bg-blue-500 hover:bg-blue-600 text-white font-semibold py-2 px-4 rounded">Sent Requests</button>
+                            </Link>
+                            <Link to="/rsvp-responses/received-invitations">
+                                <button className="w-full bg-green-500 hover:bg-green-600 text-white font-semibold py-2 px-4 rounded">Received Invitations</button>
+                            </Link>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/redux/RSVP/receivedInvitationsSlice.ts
+++ b/frontend/src/redux/RSVP/receivedInvitationsSlice.ts
@@ -1,0 +1,51 @@
+import {Invitation} from "../../dataTypes/type.ts";
+import {createAsyncThunk, createSlice} from "@reduxjs/toolkit";
+import {fetchHandler} from "../../utils/fetchHandler.ts";
+
+interface ReceivedRequests {
+    invitations: Invitation[],
+    loading: boolean,
+    error: string | null
+}
+
+const initialState: ReceivedRequests = {
+    invitations: [],
+    loading: false,
+    error: null
+}
+
+export const fetchReceivedInvitations = createAsyncThunk(
+    'receivedRequests/fetch',
+    async (_, thunkAPI) => {
+        try {
+            const res = await fetchHandler(`/invitation/received`, { credentials: 'include', method: 'GET' })
+            return await res.json()
+        } catch (err) {
+            console.log(err);
+            return thunkAPI.rejectWithValue("Something went wrong while fetching received invitations.")
+        }
+    }
+)
+
+const receivedInvitationsSlice = createSlice({
+    name: 'receivedRequests',
+    initialState,
+    reducers: {},
+    extraReducers: builder => {
+        builder
+            .addCase(fetchReceivedInvitations.pending, state => {
+                state.loading = true
+                state.error = null
+            })
+            .addCase(fetchReceivedInvitations.fulfilled, (state, action) => {
+                state.loading = false
+                state.invitations = action.payload
+            })
+            .addCase(fetchReceivedInvitations.rejected, (state, action) => {
+                state.loading = false
+                state.error = action.payload as string
+            })
+    }
+})
+
+export default receivedInvitationsSlice.reducer;

--- a/frontend/src/redux/RSVP/sentRequestsSlice.ts
+++ b/frontend/src/redux/RSVP/sentRequestsSlice.ts
@@ -1,0 +1,51 @@
+import {Request} from "../../dataTypes/type.ts";
+import {createAsyncThunk, createSlice} from "@reduxjs/toolkit";
+import {fetchHandler} from "../../utils/fetchHandler.ts";
+
+interface SentRequestState {
+    requests: Request[],
+    loading: boolean,
+    error: string | null
+}
+
+const initialState: SentRequestState = {
+    requests: [],
+    loading: false,
+    error: null
+}
+
+export const fetchSentRequests = createAsyncThunk(
+    'sentRequests/fetch',
+    async (_, thunkAPI) => {
+        try {
+            const res = await fetchHandler(`/request/sent`, { credentials: 'include', method: 'GET' })
+            return await res.json()
+        } catch (err) {
+            console.log(err);
+            return thunkAPI.rejectWithValue("Something went wrong while fetching sent requests.")
+        }
+    }
+)
+
+const sentRequestsSlice = createSlice({
+    name: 'sentRequests',
+    initialState,
+    reducers: {},
+    extraReducers: builder => {
+        builder
+            .addCase(fetchSentRequests.pending, state => {
+                state.loading = true
+                state.error = null
+            })
+            .addCase(fetchSentRequests.fulfilled, (state, action) => {
+                state.loading = false
+                state.requests = action.payload
+            })
+            .addCase(fetchSentRequests.rejected, (state, action) => {
+                state.loading = false
+                state.error = action.payload as string
+            })
+    }
+})
+
+export default sentRequestsSlice.reducer;

--- a/frontend/src/redux/event/joinedEventSlice.ts
+++ b/frontend/src/redux/event/joinedEventSlice.ts
@@ -1,0 +1,53 @@
+import {createAsyncThunk, createSlice} from '@reduxjs/toolkit'
+import {Event} from "../../dataTypes/type.ts";
+import {fetchHandler} from "../../utils/fetchHandler.ts";
+
+interface EventState {
+    events: Event[]
+    loading: boolean
+    error: string | null
+}
+
+const initialState: EventState = {
+    events: [],
+    loading: false,
+    error: null
+}
+
+export const fetchJoinedEvents = createAsyncThunk(
+    'joinedEvents/fetch',
+    async (_, thunkAPI) => {
+        try {
+            // Fetch public events
+            const res = await fetchHandler(`/event/joined`, { credentials: 'include', method: 'GET' })
+            if (!res.ok) throw new Error("Failed to fetch joined events")
+            return await res.json()
+        } catch (err) {
+            console.error(err);
+            return thunkAPI.rejectWithValue("Something went wrong while fetching joined events.")
+        }
+    }
+)
+
+const joinedEventSlice = createSlice({
+    name: 'joinedEvents',
+    initialState,
+    reducers: {},
+    extraReducers: builder => {
+        builder
+            .addCase(fetchJoinedEvents.pending, state => {
+                state.loading = true
+                state.error = null
+            })
+            .addCase(fetchJoinedEvents.fulfilled, (state, action) => {
+                state.loading = false
+                state.events = action.payload
+            })
+            .addCase(fetchJoinedEvents.rejected, (state, action) => {
+                state.loading = false
+                state.error = action.payload as string
+            })
+    }
+})
+
+export default joinedEventSlice.reducer

--- a/frontend/src/redux/store.ts
+++ b/frontend/src/redux/store.ts
@@ -3,7 +3,10 @@ import authReducer from './auth/authSlice.ts'
 import sidebarReducer from "./components/sidebarSlice.ts";
 import publicEventReducer from "./event/publicEventSlice.ts";
 import singleEventReducer from "./event/singleEventSlice.ts";
-import ownedEventsReducer from "./event/ownedEventsSlice.ts"
+import ownedEventsReducer from "./event/ownedEventsSlice.ts";
+import joinedEventReducer from "./event/joinedEventSlice.ts";
+import sentRequestsReducer from "./RSVP/sentRequestsSlice.ts";
+import receivedInvitationsReducer from "./RSVP/receivedInvitationsSlice.ts";
 
 export const store = configureStore({
     reducer: {
@@ -12,6 +15,9 @@ export const store = configureStore({
         publicEvent: publicEventReducer,
         singleEvent: singleEventReducer,
         ownedEvents: ownedEventsReducer,
+        joinedEvents: joinedEventReducer,
+        sentRequests: sentRequestsReducer,
+        receivedInvitations: receivedInvitationsReducer,
     }
 });
 

--- a/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/src/routes/AppRoutes.tsx
@@ -4,9 +4,12 @@ import LoginPage from "../pages/LoginPage.tsx";
 import RegisterPage from "../pages/RegisterPage.tsx";
 import NotFound from "../pages/NotFound.tsx";
 import EventDetail from "../pages/EventPage.tsx";
-import PublicEvents from "../pages/PublicEvents.tsx";
-import CreateEvent from "../pages/CreateEvent.tsx";
+import PublicEventPage from "../pages/PublicEventPage.tsx";
+import CreateEventPage from "../pages/CreateEventPage.tsx";
 import EventManagementPage from "../pages/EventManagementPage.tsx";
+import RSVPResponsePage from "../pages/RSVPResponsePage.tsx";
+import SentRequestsPage from "../pages/RSVPChildrenPages/SentRequestsPage.tsx";
+import ReceivedInvitationsPage from "../pages/RSVPChildrenPages/ReceivedInvitationsPage.tsx";
 
 
 export const router = createBrowserRouter([
@@ -24,7 +27,7 @@ export const router = createBrowserRouter([
     },
     {
         path: "/public-events",
-        element: <PublicEvents />
+        element: <PublicEventPage />
     },
     {
         path: "/event-detail/:id",
@@ -32,11 +35,23 @@ export const router = createBrowserRouter([
     },
     {
         path: "/create-event",
-        element: <CreateEvent />
+        element: <CreateEventPage />
     },
     {
         path: "/event-management",
         element: <EventManagementPage />
+    },
+    {
+        path: "/rsvp-responses",
+        element: <RSVPResponsePage />,
+    },
+    {
+        path: "/rsvp-responses/sent-requests",
+        element: <SentRequestsPage />
+    },
+    {
+        path: "/rsvp-responses/received-invitations",
+        element: <ReceivedInvitationsPage />
     },
     {
         path: "*" ,


### PR DESCRIPTION
1. Finish up the event management page
2. Establish a rsvp response page that lead to two additional pages.
3. Build api for calling sent requests and received invitations.
4. Have both received invitations and sent requests (invitations that have not been responded have 2 button, but they are null for now)