### PR TITLE
Did accept and reject requests.

### DIFF
--- a/backend/model/request.ts
+++ b/backend/model/request.ts
@@ -3,11 +3,11 @@ export default {
 		$jsonSchema: {
 			bsonType: "object",
 			title: "A request to join an event.",
-			required: ["senderId", "state", "eventId"],
+			required: ["Sender username", "state", "eventId"],
 			properties: {
 				_id: {},
-				senderId: {
-					bsonType: "objectId",
+				"Sender username": {
+					bsonType: "string",
 					title: "The user who sent the request."
 				},
 				state: {
@@ -16,10 +16,6 @@ export default {
 					title: "The state of the request."
 				},
 				eventId: {
-					bsonType: "objectId",
-					title: "The event to join."
-				},
-				receiverId: {
 					bsonType: "objectId",
 					title: "The event to join."
 				}

--- a/backend/queries/RequestOps.ts
+++ b/backend/queries/RequestOps.ts
@@ -20,10 +20,10 @@ g_coRouter.post("/", g_cookieParser(), async function(a_oRequest, a_oResponse) {
 			{ projection: { requests: 1 } })
 		const l_coSender = g_coUsers.findOne(
 			{ _id: ObjectId.createFromHexString(a_oRequest.session["User ID"]) },
-			{ projection: { requests: 1 } })
+			{ projection: { username: 1, requests: 1 } })
 		l_coSession.startTransaction()
 		const l_coRequest = await g_coRequests.insertOne({
-			senderId: l_coSender._id,
+			"Sender username": l_coSender.username,
 			state: "Unanswered",
 			eventId: l_coEvent._id
 		})
@@ -46,16 +46,29 @@ g_coRouter.post("/", g_cookieParser(), async function(a_oRequest, a_oResponse) {
 })
 g_coRouter.get("/", g_cookieParser(), async function(a_oRequest, a_oResponse) {
 	try {
-		a_oResponse.status(g_codes("Success")).json(await g_coRequests.findOne({
-			receiverId: ObjectId.createFromHexString(a_oRequest.session["User ID"]),
-			eventId: ObjectId.createFromHexString(a_oRequest.cookies.m_sEvent)
-		}))
+		a_oResponse.status(g_codes("Success")).json(a_oRequest.headers.all ?
+			await g_coRequests.findOne({
+				"Sender username": (await g_coUsers.findOne(
+					{ _id: ObjectId.createFromHexString(a_oRequest.session["User ID"]) },
+					{ projection: { username: 1 } }
+				)).username,
+				eventId: ObjectId.createFromHexString(a_oRequest.cookies.m_sEvent)
+			}) : await g_coRequests.find({
+				eventId: ObjectId.createFromHexString(a_oRequest.cookies.m_sEvent)
+			}).toArray())
+	} catch (a_oError) {
+		a_oResponse.status(g_codes("Server error")).json(a_oError)
+	}
+})
+g_coRouter.put("/", g_cookieParser(), async function(a_oRequest, a_oResponse) {
+	try {
+		await g_coRequests.updateOne(
+			{ _id: ObjectId.createFromHexString(a_oRequest.cookies.m_sInvitation) },
+			{ state: a_oRequest.cookies.m_sResponse })
 	} catch (a_oError) {
 		return a_oResponse.status(g_codes("Server error")).json(a_oError)
 	}
-})
-g_coRouter.put("/", function(a_oRequest, a_oResponse) {
-	
+	a_oResponse.sendStatus(g_codes("Success"))
 })
 g_coRouter.delete("/", function(a_oRequest, a_oResponse) {
 	

--- a/frontend/src/dataTypes/type.ts
+++ b/frontend/src/dataTypes/type.ts
@@ -31,6 +31,7 @@ export type Event = {
 export type Request = {
     _id: string;
     senderId: string;
+    m_oSender : User
     state: RequestStatus,
     eventId: string;
 }

--- a/frontend/src/pages/EventPage.tsx
+++ b/frontend/src/pages/EventPage.tsx
@@ -11,7 +11,7 @@ import EditEventModal from "../components/EditEventModal";
 import InviteMembersModal from "../components/InviteMembersModal";
 import { fetchHandler } from "../utils/fetchHandler"
 import { fetchCurrentUser } from "../redux/auth/authSlice";  
-import type { User } from "../dataTypes/type";
+import type { User, Request } from "../dataTypes/type";
 
 function EventDetail() {
 	const isSidebarOpen = useAppSelector(state => state.sidebar.isOpen)
@@ -32,19 +32,31 @@ function EventDetail() {
 	  // modal state
 	 const [isEditing, setIsEditing] = useState(false);
 	 const [l_coInvitation, l_coSetL_coInvitation] = useState<{ state: "Accepted" | "Unanswered" | "Rejected" } | null>(null)
+	 const [l_caInvitations, l_coSetL_caInvitations] = useState<Request[]>([])
 	useEffect(() => {
 		if (id) dispatch(fetchSingleEvent(id))
 	}, [id, dispatch])
 	useEffect(() => {
 		(async function() {
-			if (currentEvent) {
-				document.cookie = "m_sEvent=" + currentEvent._id;
-			}
+			if (currentEvent) document.cookie = "m_sEvent=" + currentEvent._id
 			const l_coResponse = await fetchHandler("/request", {
 				method: "GET",
 				credentials: "include"
 			})
-			if (l_coResponse.ok) l_coSetL_coInvitation(await l_coResponse.json()); else console.error("Error fetching requests.")
+			if (l_coResponse.ok) l_coSetL_coInvitation(await l_coResponse.json())
+			else console.error("Error fetching requests.")
+		})()
+	})
+	useEffect(() => {
+		(async function() {
+			if (currentEvent) document.cookie = "m_sEvent=" + currentEvent._id
+			const l_coResponse = await fetchHandler("/request", {
+				method: "GET",
+				credentials: "include",
+				["all" as any]: null
+			})
+			if (l_coResponse.ok) l_coSetL_caInvitations(await l_coResponse.json())
+			else console.error("Error fetching requests.")
 		})()
 	})
 	useEffect(() => {
@@ -127,10 +139,39 @@ function EventDetail() {
 							<div className="lg:col-span-1">
 								<div className="bg-white p-6 rounded-lg shadow-md mb-6">
 								{ownedPara !== null &&(ownedPara === "true" ? (
+									<div>
 										<button  onClick={openEdit}
 										className="w-full bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-6 rounded-full transition-colors">
 											Edit Event Details
 										</button>
+										<ul>
+											{ l_caInvitations.map(l_coInvitation => (
+												<div>
+													<li>{l_coInvitation.m_oSender.username}</li>
+													<button onClick={
+														async function(a_oEvent) {
+															if (currentEvent) document.cookie = "m_sInvitation=" + l_coInvitation._id
+															document.cookie = "m_sResponse=" + a_oEvent.currentTarget.textContent + "ed"
+															alert((await fetchHandler("/request", {
+																method: "PUT",
+																credentials: "include"
+															})).ok ? "Success." : "Failure.")
+														}
+													}>Accept</button>
+													<button onClick={
+														async function(a_oEvent) {
+															if (currentEvent) document.cookie = "m_sInvitation=" + l_coInvitation._id
+															document.cookie = "m_sResponse=" + a_oEvent.currentTarget.textContent + "ed"
+															alert((await fetchHandler("/request", {
+																method: "PUT",
+																credentials: "include"
+															})).ok ? "Success." : "Failure.")
+														}
+													}>Reject</button>
+												</div>
+											)) }
+										</ul>
+									</div>
 										) : l_coInvitation ? (
 											l_coInvitation.state === "Accepted" ? (<button>Discussion board</button>) :
 											l_coInvitation.state === "Unanswered" ? (<p>Request not answered</p>) :


### PR DESCRIPTION

This pull request introduces changes to the request handling system, focusing on replacing `senderId` with `Sender username`, updating the backend request schema and queries, and enhancing the frontend to display and manage event invitations. The most important changes are grouped below by theme.

### Backend Changes

* **Schema Update**: Replaced the `senderId` field with `Sender username` in the `request` schema. `Sender username` is now a `string` instead of an `objectId` (`backend/model/request.ts`). [[1]](diffhunk://#diff-92e208cad0bd27f6adcebce811406a70fc76501dbf26a8fbda49727c5f3b7d04L6-R10) [[2]](diffhunk://#diff-92e208cad0bd27f6adcebce811406a70fc76501dbf26a8fbda49727c5f3b7d04L21-L24)
* **Query Adjustments**: Updated backend queries to use `Sender username` instead of `senderId`. Added support for fetching all invitations for an event and updating request states (`backend/queries/RequestOps.ts`). [[1]](diffhunk://#diff-a5accb3139dc0e18511b365b53a88641f5186348ddfc2618c3bb8dc5890405faL23-R26) [[2]](diffhunk://#diff-a5accb3139dc0e18511b365b53a88641f5186348ddfc2618c3bb8dc5890405faL49-R71)

### Frontend Changes

* **Type Update**: Added a `m_oSender` field of type `User` to the `Request` type to include sender details (`frontend/src/dataTypes/type.ts`).
* **State Management**: Introduced a new state variable `l_caInvitations` to manage a list of invitations in the `EventDetail` component (`frontend/src/pages/EventPage.tsx`).
* **UI Enhancements**: Added a UI section for event owners to view and manage invitations, including buttons to accept or reject requests (`frontend/src/pages/EventPage.tsx`).